### PR TITLE
Used UUID to generate unique folder name.

### DIFF
--- a/apps/build_man/lib/build_man/file_helpers.ex
+++ b/apps/build_man/lib/build_man/file_helpers.ex
@@ -1,10 +1,8 @@
 defmodule BuildMan.FileHelpers do
   def unique_folder(prefix \\ "") do
-    system_tmp = System.tmp_dir
-    {a, b, c} = :erlang.now
-    n = node
-    dir_name = "#{prefix}#{n}-#{a}.#{b}.#{c}"
-    tmp_path = Path.join([system_tmp, "RabbitCI", dir_name])
+    dir_name = "#{prefix}-#{UUID.uuid4()}"
+    tmp_path = Path.join([System.tmp_dir, "RabbitCI", dir_name])
+
     case File.mkdir_p(tmp_path) do
       :ok -> {:ok, tmp_path}
     end

--- a/apps/build_man/mix.exs
+++ b/apps/build_man/mix.exs
@@ -38,6 +38,7 @@ defmodule BuildMan.Mixfile do
     [{:excoveralls, "~> 0.3.0", only: [:dev, :test]},
      {:amqp, "0.1.1"},
      {:mock, "0.1.1"},
-     {:exec, github: "saleyn/erlexec"}]
+     {:exec, github: "saleyn/erlexec"},
+     {:uuid, "~> 1.0.1"}]
   end
 end


### PR DESCRIPTION
I have used `UUID.uuid4(:hex)` to remove the dash characters from the folder name.

```
iex(1)> UUID.uuid4(:hex)
"69a7d3487b804f98afec3bbf8bbde90a"

iex(2)> UUID.uuid4()
"58f5919d-045e-4be9-be8a-5c3e8383f2d3"
```

Closes #17 
