### PR TITLE
Disconnect LogStreamer from Vagrant

### DIFF
--- a/apps/build_man/config/config.exs
+++ b/apps/build_man/config/config.exs
@@ -18,6 +18,7 @@ config :build_man, :config_extraction_limit, 2
 config :build_man, :log_streamer_limit, 10
 
 config :build_man, :build_logs_exchange, "rabbitci.build_logs"
+config :build_man, :build_logs_queue, "rabbitci.build_logs"
 config :build_man, :build_exchange, "rabbitci.builds"
 config :build_man, :build_queue, "rabbitci.builds"
 config :build_man, :config_extraction_exchange, "rabbitci.config_extraction"

--- a/apps/build_man/config/test.exs
+++ b/apps/build_man/config/test.exs
@@ -1,6 +1,7 @@
 use Mix.Config
 
 config :build_man, :build_logs_exchange, "rabbitci.build_logs.test"
+config :build_man, :build_logs_queue, "rabbitci.build_logs.test"
 config :build_man, :build_exchange, "rabbitci.builds.test"
 config :build_man, :build_queue, "rabbitci.builds.test"
 config :build_man, :config_extraction_exchange, "rabbitci.config_extraction.test"

--- a/apps/build_man/lib/build_man.ex
+++ b/apps/build_man/lib/build_man.ex
@@ -9,6 +9,7 @@ defmodule BuildMan do
     children = [
       worker(BuildMan.BuildConsumer, []),
       worker(BuildMan.ConfigExtractionSup, []),
+      worker(BuildMan.LogStreamer, []),
     ]
 
     opts = [strategy: :one_for_one, name: BuildMan.Supervisor,

--- a/apps/build_man/lib/build_man/build_consumer.ex
+++ b/apps/build_man/lib/build_man/build_consumer.ex
@@ -2,8 +2,6 @@ defmodule BuildMan.BuildConsumer do
   use AMQP
   use GenServer
   alias BuildMan.Vagrant
-  alias RabbitCICore.Step
-  alias RabbitCICore.Repo
   require Logger
 
   def start_link do

--- a/apps/build_man/lib/build_man/log_streamer.ex
+++ b/apps/build_man/lib/build_man/log_streamer.ex
@@ -7,50 +7,38 @@ defmodule BuildMan.LogStreamer do
   use AMQP
   use GenServer
   alias BuildMan.LogProcessor
+  alias BuildMan.LogOutput
 
   # Client API
   @doc """
-  Starts the log streamer. `opts` must be a tuple in the format:
-
-      {pid, build_identifier}
-
-  With the values being:
-
-  `pid`: The pid of the process that should be monitored. When that process
-  shuts down, the LogStreamer will finish processing the messages in the queue
-  and shut down as well. This should generally be the return value of `self/1`.
-
-  `build_identifier`: A unique identifier for the build. This is use to
-  determine the routing key to bind the queue.
+  Starts the log streamer.
   """
-  def start(opts) do
+  def start_link do
     Logger.debug("Starting up LogStreamer...")
-    GenServer.start(__MODULE__, opts)
+    GenServer.start_link(__MODULE__, [])
   end
 
   @exchange Application.get_env(:build_man, :build_logs_exchange)
+  @queue Application.get_env(:build_man, :build_logs_queue)
   @log_streamer_limit Application.get_env(:build_man, :log_streamer_limit)
 
-  def log_string(str, type, build_identifier, order, build_id, step_name) do
-    # publish(exchange, routing_key, payload, options \\ [])
-    map = %{text: str, order: order, build_id: build_id, step_name: step_name}
-    RabbitMQ.publish(@exchange, "#{type}.#{build_identifier}",
+  def log_string(str, type, order, step_id) do
+    map = %LogOutput{text: str, order: order, step_id: step_id, type: type}
+    RabbitMQ.publish(@exchange, "#{type}.#{step_id}",
                      :erlang.term_to_binary(map))
   end
 
   # Server callbacks
-  def init({ref, build_identifier}) do
-    Process.monitor(ref)
-
+  def init([]) do
     open_chan = RabbitMQ.with_conn fn conn ->
       {:ok, chan} = Channel.open(conn)
       Basic.qos(chan, prefetch_count: @log_streamer_limit)
-      {:ok, %{queue: queue}} = Queue.declare(chan, "", auto_delete: true)
+      {:ok, %{queue: queue}} = Queue.declare(chan, @queue, durable: true)
       Exchange.topic(chan, @exchange)
-      Queue.bind(chan, "", @exchange, routing_key: "#.#{build_identifier}")
+      Queue.bind(chan, @queue, @exchange, routing_key: "#")
 
       {:ok, _consumer_tag} = Basic.consume(chan, queue)
-      {:ok, %{chan: chan, ref: ref, stop: false, queue: queue}}
+      {:ok, %{chan: chan, queue: queue}}
     end
 
     case open_chan do
@@ -62,60 +50,33 @@ defmodule BuildMan.LogStreamer do
     end
   end
 
-  # AMQP Stuff
   def handle_info({:basic_consume_ok, _}, state) do
-    {:ok, hostname} = :inet.gethostname
-    Logger.info("BuildMan.LogStreamer started on #{hostname}")
+    Logger.info("BuildMan.LogStreamer connected to RabbitMQ.")
     {:noreply, state}
   end
-
-  def handle_info({:basic_cancel, _}, state), do: {:stop, :normal, state}
-  def handle_info({:basic_cancel_ok, _}, state), do: {:noreply, state}
-
   def handle_info({:basic_deliver, raw_payload,
-                   %{delivery_tag: tag, routing_key: routing_key}},
-                  state = %{chan: chan, ref: _ref, stop: stop, queue: queue})
+                   %{delivery_tag: tag, routing_key: _routing_key}},
+                  state = %{chan: chan, queue: _queue})
   do
-    count = Queue.message_count(chan, queue)
-
     Task.start fn ->
       try do
-        payload = :erlang.binary_to_term(raw_payload)
-        LogProcessor.process(payload, routing_key)
+        payload = %LogOutput{} = :erlang.binary_to_term(raw_payload)
+        LogProcessor.process(payload)
       after
         Basic.ack(chan, tag)
       end
     end
 
-    case {count, stop} do
-      {0, true} -> shut_down(state)
-      _ -> {:noreply, state}
-    end
-  end
-
-  # This is what is called when the process we were monitoring dies. If the
-  # queue is empty, we shut down. If not, we set the third value in the state
-  # tuple to true which will be picked up on the next processed message.
-  def handle_info({:DOWN, ref, :process, _pid, _reason},
-                  {chan, ref2, _stop, queue}) when ref == ref2 do
-    case Queue.message_count(chan, queue) do
-      0 -> shut_down({chan, ref2, true, queue})
-      _ -> {:noreply, {chan, ref2, true, queue}}
-    end
-  end
-
-  # Channel died.
-  def handle_info({:DOWN, _ref, :process, _pid, reason}, state) do
-    case reason do
-      :normal -> Logger.debug("RabbitMQ Channel shut down")
-      _ -> Logger.warn("RabbitMQ Channel died!")
-    end
-    shut_down(state)
-  end
-
-  def handle_info(_msg, state) do
     {:noreply, state}
   end
+  # Channel died.
+  def handle_info({:DOWN, _ref, :process, _pid, reason}, state) do
+    Logger.warn("RabbitMQ Channel died! #{inspect reason}")
+    shut_down(state)
+  end
+  def handle_info({:basic_cancel, _}, state), do: {:stop, :normal, state}
+  def handle_info({:basic_cancel_ok, _}, state), do: {:noreply, state}
+  def handle_info(_msg, state), do: {:noreply, state}
 
   defp shut_down(state) do
     Logger.debug("Log streamer going down... #{inspect state}")
@@ -128,38 +89,5 @@ defmodule BuildMan.LogStreamer do
     catch
       _, _ -> :ok
     end
-  end
-end
-
-defmodule BuildMan.LogProcessor do
-  alias RabbitCICore.Repo
-  alias RabbitCICore.Log
-  alias RabbitCICore.Step
-
-  require Logger
-
-  def process(payload = %{text: text, order: order}, order,
-              "stderr." <> identifier)
-  do
-    do_process(payload, "stderr", identifier)
-    Logger.debug "STDERR (#{identifier}:#{order}): #{String.strip text}"
-    # Do something
-  end
-
-  def process(payload = %{text: text, order: order}, "stdout." <> identifier) do
-    do_process(payload, "stdout", identifier)
-    Logger.debug "STDOUT (#{identifier}:#{order}): #{String.strip text}"
-  end
-
-  def process(payload, other) do
-    Logger.warn("Log with unknown identifier: #{other} #{inspect payload}")
-  end
-
-  defp do_process(%{build_id: build_id, step_name: step_name, text: text,
-                    order: order}, type, identifier) do
-    Repo.get_by(Step, name: step_name, build_id: build_id)
-    |> Ecto.Model.build(:logs)
-    |> Log.changeset(%{stdio: text, order: order, type: type})
-    |> Repo.insert!
   end
 end

--- a/apps/build_man/lib/build_man/logs/log_output.ex
+++ b/apps/build_man/lib/build_man/logs/log_output.ex
@@ -1,0 +1,18 @@
+defmodule BuildMan.LogOutput do
+  alias BuildMan.LogOutput
+  alias RabbitCICore.Repo
+  alias RabbitCICore.Step
+  alias RabbitCICore.Log
+
+  defstruct order: nil, text: "", type: "stdout", step_id: -1
+
+  def save!(%LogOutput{step_id: step_id,
+                       text: text,
+                       order: order,
+                       type: type}) do
+    Repo.get!(Step, step_id, log: false)
+    |> Ecto.Model.build(:logs)
+    |> Log.changeset(%{stdio: text, order: order, type: type})
+    |> Repo.insert!(log: false)
+  end
+end

--- a/apps/build_man/lib/build_man/logs/log_processor.ex
+++ b/apps/build_man/lib/build_man/logs/log_processor.ex
@@ -1,0 +1,11 @@
+defmodule BuildMan.LogProcessor do
+  alias RabbitCICore.Repo
+  alias RabbitCICore.Log
+  alias RabbitCICore.Step
+  alias BuildMan.LogOutput
+  require Logger
+
+  def process(log = %{type: type}) when type in ["stdout", "stderr"] do
+    LogOutput.save!(log)
+  end
+end

--- a/apps/rabbitci_core/web/models/step.ex
+++ b/apps/rabbitci_core/web/models/step.ex
@@ -41,7 +41,7 @@ defmodule RabbitCICore.Step do
   end
 
   # This is for use in BuildMan.Vagrant. You can use it, but you probably
-  # shouldn't as it uses step_id instead of an actual step.
+  # shouldn't as it uses step_id instead of a %Step{}.
   def update_status!(step_id, status) do
     Repo.get!(Step, step_id)
     |> Step.changeset(%{status: status})


### PR DESCRIPTION
The LogStreamer is no longer connected to Vagrant. Vagrant has also been
made easier to shut down correctly.

Closes #40.
